### PR TITLE
fix Rack::Lint::LintError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ group :development, :test do
   gem 'pry'
 end
 group :test do
-  gem 'rack'
+  gem 'rack', "< 3" # https://github.com/rack/rack/issues/1592
   gem 'timecop'
 end
-


### PR DESCRIPTION
fix dependency to avoid to use rack 3

https://github.com/rack/rack/issues/1592

```
  1) Rack::ServerStatus confirm to Rack::Lint Not affected WorkerScoreboard
     Failure/Error: response = Rack::MockRequest.new(subject).get('/')

     Rack::Lint::LintError:
       uppercase character in header name: Content-Type
```